### PR TITLE
Add NetAdressable and Networking Support

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshComponent.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshComponent.cpp
@@ -402,6 +402,8 @@ URuntimeMeshComponent::URuntimeMeshComponent(const FObjectInitializer& ObjectIni
 
 	// Reset the batch state
 	BatchState.ResetBatch();
+
+	SetNetAddressable();
 }
 
 TSharedPtr<FRuntimeMeshSectionInterface> URuntimeMeshComponent::CreateOrResetSectionInternalType(int32 SectionIndex, int32 NumUVChannels, bool WantsHalfPrecsionUVs)

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
@@ -137,6 +137,10 @@ private:
 public:
 	URuntimeMeshComponent(const FObjectInitializer& ObjectInitializer);
 	
+	virtual bool IsSupportedForNetworking() const override
+	{
+		return true;
+	}
 
 	/**
 	*	Create/replace a section.


### PR DESCRIPTION
UCharacterMovementComponent will complain on the client if it is
standing on a component that is not net addressable.