### PR TITLE
Fixed failure to convert RMC to SMC when mesh consisted of a single triangle

### DIFF
--- a/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentDetails.cpp
+++ b/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentDetails.cpp
@@ -196,7 +196,7 @@ FReply FRuntimeMeshComponentDetails::ClickedOnConvertToStaticMesh()
  			}
  
  			// If we got some valid data.
- 			if (RawMesh.VertexPositions.Num() > 3 && RawMesh.WedgeIndices.Num() > 3)
+ 			if (RawMesh.VertexPositions.Num() >= 3 && RawMesh.WedgeIndices.Num() >= 3)
  			{
  				// Then find/create it.
  				UPackage* Package = CreatePackage(NULL, *UserPackageName);


### PR DESCRIPTION
Addressed simple off by one error to now consider 3 vertices and 3
indices as valid data when converting RMC to SMC.