### PR TITLE
Fix to get RMC building on UE 4.15.

### DIFF
--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
@@ -68,6 +68,15 @@ struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshComponentPrePhysicsTickFunction : pu
 	virtual FString DiagnosticMessage() override;
 };
 
+template<>
+struct TStructOpsTypeTraits<FRuntimeMeshComponentPrePhysicsTickFunction> : public TStructOpsTypeTraitsBase
+{
+	enum
+	{
+		WithCopy = false
+	};
+};
+
 /**
 *	Component that allows you to specify custom triangle mesh geometry for rendering and collision.
 */


### PR DESCRIPTION
RMC wouldn't build for me on Unreal Engine 4.15. I traced the build error to a missing type trait. 

The WithCopy= false type trait from FTickFunction needs to be declared for the child type trait too.
